### PR TITLE
feat(automapper): adds an interface that implements reverse mapping

### DIFF
--- a/samples/FluentUtils.AutoMapper.Samples/Controllers/UsersController.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Controllers/UsersController.cs
@@ -1,0 +1,38 @@
+﻿using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Commands;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FluentUtils.AutoMapper.Samples.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    /// <inheritdoc />
+    public UsersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<UserDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAsync(CancellationToken cancellationToken)
+    {
+        GetUsersQuery query = new();
+        List<UserDto> result = await _mediator.Send(query, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> AddAsync([FromBody] UserDto user, CancellationToken cancellationToken)
+    {
+        AddUserCommand command = new() { User = user };
+        UserDto result = await _mediator.Send(command, cancellationToken);
+        return Ok(result);
+    }
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Commands/AddUserCommand.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Commands/AddUserCommand.cs
@@ -1,0 +1,31 @@
+﻿using AutoMapper;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Contracts;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+using MediatR;
+
+namespace FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Commands;
+
+public class AddUserCommand : IRequest<UserDto>
+{
+    public UserDto User { get; init; } = null!;
+
+    public class Handler : IRequestHandler<AddUserCommand, UserDto>
+    {
+        private readonly IUserService _userService;
+        private readonly IMapper _mapper;
+
+        public Handler(IUserService userService, IMapper mapper)
+        {
+            _userService = userService;
+            _mapper = mapper;
+        }
+
+        /// <inheritdoc />
+        public async Task<UserDto> Handle(AddUserCommand request, CancellationToken cancellationToken)
+        {
+            var toAdd = _mapper.Map<User>(request.User);
+            User added = await _userService.AddAsync(toAdd, cancellationToken);
+            return _mapper.Map<UserDto>(added);
+        }
+    }
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Contracts/IUserService.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Contracts/IUserService.cs
@@ -1,0 +1,9 @@
+﻿using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+
+namespace FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Contracts;
+
+public interface IUserService
+{
+    Task<List<User>> ListAsync(CancellationToken cancellationToken);
+    Task<User> AddAsync(User user, CancellationToken cancellationToken);
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Models/User.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Models/User.cs
@@ -1,0 +1,8 @@
+﻿namespace FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+
+public class User
+{
+    public int Id { get; set; }
+    public string FullName { get; set; } = string.Empty;
+    public DateTime Created { get; set; } = DateTime.Now;
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Models/UserDto.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Models/UserDto.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+
+public class UserDto : IReverseMapFrom<User>
+{
+    public int Id { get; set; }
+    public string FullName { get; set; } = null!;
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Queries/GetUsersQuery.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Core/WeatherForecasts/Queries/GetUsersQuery.cs
@@ -1,0 +1,28 @@
+﻿using AutoMapper;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Contracts;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+using MediatR;
+
+namespace FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Queries;
+
+public class GetUsersQuery : IRequest<List<UserDto>>
+{
+    public class Handler : IRequestHandler<GetUsersQuery, List<UserDto>>
+    {
+        private readonly IUserService _userService;
+        private readonly IMapper _mapper;
+
+        public Handler(IUserService userService, IMapper mapper)
+        {
+            _userService = userService;
+            _mapper = mapper;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<UserDto>> Handle(GetUsersQuery request, CancellationToken cancellationToken)
+        {
+            List<User> users = await _userService.ListAsync(cancellationToken);
+            return _mapper.Map<List<UserDto>>(users);
+        }
+    }
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Infrastructure/Services/UserService.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Infrastructure/Services/UserService.cs
@@ -1,0 +1,24 @@
+﻿using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Contracts;
+using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
+
+namespace FluentUtils.AutoMapper.Samples.Infrastructure.Services;
+
+public class UserService : IUserService
+{
+    /// <inheritdoc />
+    public async Task<List<User>> ListAsync(CancellationToken cancellationToken)
+    {
+        return await Task.FromResult(
+            new List<User>
+            {
+                new() { Id = 1, FullName = "Matthew Mercer" },
+                new() { Id = 2, FullName = "Laura Bailey" },
+            }
+        );
+    }
+    /// <inheritdoc />
+    public async Task<User> AddAsync(User user, CancellationToken cancellationToken)
+    {
+        return await Task.FromResult(user);
+    }
+}

--- a/samples/FluentUtils.AutoMapper.Samples/Program.cs
+++ b/samples/FluentUtils.AutoMapper.Samples/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddAutoMapperProfiles(typeof(Program).Assembly);
 builder.Services.AddScoped<IWeatherForecastService, WeatherForecastService>();
+builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddMediatR(typeof(Program).Assembly);
 
 var app = builder.Build();

--- a/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/README.md
+++ b/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/README.md
@@ -3,7 +3,7 @@
 ## Example Usage
 
 Use `AddAutoMapperProfiles` and pass it a params array of assemblies which contain
-classes implementing the `IMapFrom<>` interface.
+classes implementing the `IMapFrom<>` and `IReverseMapFrom<>` interfaces.
 
 ```csharp
 // Program.cs
@@ -12,3 +12,39 @@ var builder = WebApplication.CreateBuilder(args);
 // Register automapper profiles in the assembly containing the Program class
 builder.Services.AddAutoMapperProfiles(typeof(Program).Assembly);
 ```
+
+### IMapFrom<>
+
+```csharp
+public class User
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; }
+    public DateTime Created { get; set; }
+}
+
+// This will allow automapper to map Users to UserDtos
+public class UserDto : IMapFrom<User>
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; }
+}
+``` 
+
+### IReverseMapFrom<>
+
+```csharp
+public class User
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; }
+    public DateTime Created { get; set; }
+}
+
+// This will allow automapper to map Users to UserDtos and then back to Users
+public class UserDto : IReverseMapFrom<User>
+{
+    public Guid Id { get; set; }
+    public string FullName { get; set; }
+}
+``` 

--- a/src/FluentUtils.AutoMapper/IReverseMapFrom.cs
+++ b/src/FluentUtils.AutoMapper/IReverseMapFrom.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+
+namespace FluentUtils.AutoMapper
+{
+    /// <summary>
+    ///     Indicates a mapping relationship between the source type T and the current type
+    ///     (class implementing this interface) which is reversible.
+    /// </summary>
+    /// <typeparam name="TSource">The source type.</typeparam>
+    public interface IReverseMapFrom<TSource>
+    {
+        /// <summary>
+        ///     Creates a reversible mapping profile from the source type T to the
+        ///     destination type (class that implements this interface).
+        /// </summary>
+        /// <param name="profile"></param>
+        void Mapping(Profile profile)
+        {
+            profile.CreateMap(typeof(TSource), GetType())
+                   .ReverseMap();
+        }
+    }
+}

--- a/src/FluentUtils.AutoMapper/MappingProfile.cs
+++ b/src/FluentUtils.AutoMapper/MappingProfile.cs
@@ -7,71 +7,104 @@ using AutoMapper;
 namespace FluentUtils.AutoMapper
 {
 
-/// <summary>
-///     A helper class for registering all types implementing IMapFrom
-///     with AutoMapper.
-/// </summary>
-public class MappingProfile : Profile
-{
-    private const string MappingMethodName = "Mapping";
-    private const string MappingInterface = "IMapFrom`1";
-
     /// <summary>
-    ///     Creates a new mapping profile.
+    ///     A helper class for registering all types implementing IMapFrom
+    ///     with AutoMapper.
     /// </summary>
-    public MappingProfile()
+    public class MappingProfile : Profile
     {
-        InvokeMappingsFromAssemblies(AssembliesUsingIMapFrom);
-    }
+        private const string MappingMethodName = "Mapping";
+        private const string MappingInterface = "IMapFrom`1";
+        private const string ReverseMappingInterface = "IReverseMapFrom`1";
 
-    /// <summary>
-    ///     An enumerable of assemblies that have classes which implement IMapFrom.
-    ///     Used when registering the mapping profile.
-    /// </summary>
-    public static IEnumerable<Assembly> AssembliesUsingIMapFrom { get; set; } = Array.Empty<Assembly>();
-
-    /// <summary>
-    ///     Invokes the mapping methods found in the provided assemblies.
-    /// </summary>
-    /// <param name="assembliesUsingIMapFrom">The assemblies containing types that implement IMapFrom.</param>
-    private void InvokeMappingsFromAssemblies(IEnumerable<Assembly> assembliesUsingIMapFrom)
-    {
-        foreach (Assembly assembly in assembliesUsingIMapFrom)
+        /// <summary>
+        ///     Creates a new mapping profile.
+        /// </summary>
+        public MappingProfile()
         {
-            IEnumerable<Type> typesImplementingIMapFrom = GetTypesImplementingIMapFromInAssembly(assembly);
-            InvokeMappingMethod(typesImplementingIMapFrom);
+            InvokeMappingsFromAssemblies(AssembliesUsingIMapFrom);
+        }
+
+        /// <summary>
+        ///     An enumerable of assemblies that have classes which implement IMapFrom and IReverseMapFrom.
+        ///     Used when registering the mapping profile.
+        /// </summary>
+        public static IEnumerable<Assembly> AssembliesUsingIMapFrom { get; set; } = Array.Empty<Assembly>();
+
+        /// <summary>
+        ///     Invokes the mapping methods found in the provided assemblies.
+        /// </summary>
+        /// <param name="assembliesUsingIMapFrom">The assemblies containing types that implement IMapFrom.</param>
+        private void InvokeMappingsFromAssemblies(IEnumerable<Assembly> assembliesUsingIMapFrom)
+        {
+            foreach (Assembly assembly in assembliesUsingIMapFrom)
+            {
+                Type[] exportedTypes = assembly.GetExportedTypes();
+                IEnumerable<Type> typesImplementingIMapFrom = GetTypesImplementingIMapFromInAssembly(exportedTypes);
+                IEnumerable<Type> typesImplementingIReverseMapFrom =
+                    GetTypesImplementingIReverseMapFromInAssembly(exportedTypes);
+
+                InvokeMappingMethod(typesImplementingIMapFrom, typesImplementingIReverseMapFrom);
+            }
+        }
+
+        /// <summary>
+        ///     Gets the types which implement IMapFrom from the provided types.
+        /// </summary>
+        /// <param name="exportedTypes">The types present in the current assembly.</param>
+        /// <returns>The list of types that implement IMapFrom.</returns>
+        private static IEnumerable<Type> GetTypesImplementingIMapFromInAssembly(IEnumerable<Type> exportedTypes)
+        {
+            return exportedTypes.Where(TypeImplementsIMapFrom());
+
+            Func<Type, bool> TypeImplementsIMapFrom() => type => type.GetInterfaces().Any(InterfaceIsIMapFrom());
+
+            Func<Type, bool> InterfaceIsIMapFrom() => @interface =>
+                @interface.IsGenericType && @interface.GetGenericTypeDefinition() == typeof(IMapFrom<>);
+        }
+
+        /// <summary>
+        ///     Gets the types which implement IReverseMapFrom from the provided types.
+        /// </summary>
+        /// <param name="exportedTypes">The types present in the current assembly.</param>
+        /// <returns>The list of types that implement IReverseMapFrom.</returns>
+        private static IEnumerable<Type> GetTypesImplementingIReverseMapFromInAssembly(IEnumerable<Type> exportedTypes)
+        {
+            return exportedTypes.Where(TypeImplementsIReverseMapFrom());
+
+            Func<Type, bool> TypeImplementsIReverseMapFrom() =>
+                type => type.GetInterfaces().Any(InterfaceIsIReverseMapFrom());
+
+            Func<Type, bool> InterfaceIsIReverseMapFrom() => @interface =>
+                @interface.IsGenericType && @interface.GetGenericTypeDefinition() == typeof(IReverseMapFrom<>);
+        }
+
+        /// <summary>
+        ///     Invokes the mapping method in the provided types.
+        /// </summary>
+        /// <param name="typesImplementingIMapFrom">The collection of types that implement IMapFrom.</param>
+        /// <param name="typesImplementingIReverseMapFrom">The collection of types that implement IReverseMapFrom.</param>
+        private void InvokeMappingMethod(
+            IEnumerable<Type> typesImplementingIMapFrom,
+            IEnumerable<Type> typesImplementingIReverseMapFrom)
+        {
+            foreach (Type type in typesImplementingIMapFrom)
+            {
+                object? instance = Activator.CreateInstance(type);
+                MethodInfo? methodInfo = type.GetMethod(MappingMethodName)
+                                      ?? type.GetInterface(MappingInterface)?.GetMethod(MappingMethodName);
+
+                methodInfo?.Invoke(instance, new object?[] { this });
+            }
+
+            foreach (Type type in typesImplementingIReverseMapFrom)
+            {
+                object? instance = Activator.CreateInstance(type);
+                MethodInfo? methodInfo = type.GetMethod(MappingMethodName)
+                                      ?? type.GetInterface(ReverseMappingInterface)?.GetMethod(MappingMethodName);
+
+                methodInfo?.Invoke(instance, new object?[] { this });
+            }
         }
     }
-
-    /// <summary>
-    ///     Gets the types which implement IMapFrom from the provided assembly.
-    /// </summary>
-    /// <param name="assembly">An assembly.</param>
-    /// <returns>The list of types that implement IMapFrom.</returns>
-    private static IEnumerable<Type> GetTypesImplementingIMapFromInAssembly(Assembly assembly)
-    {
-        Type[] exportedTypes = assembly.GetExportedTypes();
-        return exportedTypes.Where(TypeImplementsIMapFrom());
-
-        Func<Type, bool> TypeImplementsIMapFrom() => type => type.GetInterfaces().Any(InterfaceIsIMapFrom());
-        Func<Type, bool> InterfaceIsIMapFrom() => @interface => @interface.IsGenericType && @interface.GetGenericTypeDefinition() == typeof(IMapFrom<>);
-    }
-
-    /// <summary>
-    ///     Invokes the mapping method in the provided types.
-    /// </summary>
-    /// <param name="typesImplementingIMapFrom">The list of types that implement IMapFrom.</param>
-    private void InvokeMappingMethod(IEnumerable<Type> typesImplementingIMapFrom)
-    {
-        foreach (Type type in typesImplementingIMapFrom)
-        {
-            object? instance = Activator.CreateInstance(type);
-            MethodInfo? methodInfo = type.GetMethod(MappingMethodName)
-                                  ?? type.GetInterface(MappingInterface)?.GetMethod(MappingMethodName);
-
-            methodInfo?.Invoke(instance, new object?[] { this });
-        }
-    }
-}
-
 }

--- a/tests/FluentUtils.AutoMapper.UnitTests/AddAutoMapperProfileFacts.cs
+++ b/tests/FluentUtils.AutoMapper.UnitTests/AddAutoMapperProfileFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentUtils.AutoMapper.Samples.Core.WeatherForecasts.Models;
@@ -29,5 +30,41 @@ public class AddAutoMapperProfileFacts : IClassFixture<WebApplicationFactory<Pro
 
         // ASSERT
         response.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GivenIReverseMapFrom_WhenGettingUsers_ThenReturnUsers()
+    {
+        // ARRANGE
+        HttpClient client = _factory.CreateClient();
+
+        var expected = new List<UserDto>
+        {
+            new() { Id = 1, FullName = "Matthew Mercer" },
+            new() { Id = 2, FullName = "Laura Bailey" },
+        };
+
+        // ACT
+        var response = await client.GetFromJsonAsync<List<UserDto>>("Users");
+
+        // ASSERT
+        response.Should().NotBeNull();
+        response.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GivenIReverseMapFrom_WhenAddingUsers_ThenSucceed()
+    {
+        // ARRANGE
+        HttpClient client = _factory.CreateClient();
+        UserDto expected = new() { Id = 1, FullName = "Matthew Mercer" };
+
+
+        // ACT
+        HttpResponseMessage responseMessage = await client.PostAsJsonAsync("Users", expected, default);
+        var response = await responseMessage.Content.ReadFromJsonAsync<UserDto>();
+
+        // ASSERT
+        response.Should().BeEquivalentTo(expected);
     }
 }


### PR DESCRIPTION
This feature introduces the below usage in order to have a default reverse map.

```csharp
public class User
{
    public Guid Id { get; set; }
    public string FullName { get; set; }
    public DateTime Created { get; set; }
}
// This will allow automapper to map Users to UserDtos and then back to Users
public class UserDto : IReverseMapFrom<User>
{
    public Guid Id { get; set; }
    public string FullName { get; set; }
}
``` 