### PR TITLE
feat(mediatr-pagination): remove init only setter for limit in paginated request

### DIFF
--- a/src/FluentUtils.MediatR.Pagination/PaginatedRequest.cs
+++ b/src/FluentUtils.MediatR.Pagination/PaginatedRequest.cs
@@ -9,7 +9,7 @@ namespace FluentUtils.MediatR.Pagination
     /// <typeparam name="TResult">The return data type for the results IEnumerable.</typeparam>
     public abstract class PaginatedRequest<TResult> : IRequest<PaginatedResponse<TResult>>
     {
-        private readonly int? _limit;
+        private int? _limit;
 
         /// <summary>
         /// Gets or initializes the maximum number of records to return.
@@ -18,13 +18,13 @@ namespace FluentUtils.MediatR.Pagination
         public int Limit
         {
             get => _limit ?? 10;
-            init
+            set
             {
                 _limit = value switch
                 {
                     < 1 => 10,
                     > 100 => 100,
-                    _ => value
+                    var _ => value,
                 };
             }
         }


### PR DESCRIPTION
Changes the `Limit` prop inside the `PaginatedRequest<TResult>` abstract class to not be `init` only

closes #17 