### PR TITLE
feat: create domain driven enums project

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine Version
         id: gitversion
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -294,7 +294,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -306,6 +306,34 @@ jobs:
         run: |
           dotnet nuget push ./src/FluentUtils.EnumExtensions/out/*.nupkg --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
           dotnet nuget push ./src/FluentUtils.EnumExtensions/out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  publish-domain-driven-enums:
+    runs-on: ubuntu-latest
+    needs:
+      - calculate-version
+    name: Publish domain driven enums NuGet package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core Latest
+        uses: actions/setup-dotnet@v1
+        with:
+          source-url: https://nuget.pkg.github.com/draekien/index.json
+          dotnet-version: "6.0.x"
+          include-prerelease: true
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and pack
+        run: cd src/FluentUtils.DomainDrivenEnums && dotnet pack -c Release -o out -p:PackageVersion=${{ needs.calculate-version.outputs.nuGetVersionV2 }}
+
+      - name: Publish
+        run: |
+          dotnet nuget push ./src/FluentUtils.DomainDrivenEnums/out/*.nupkg --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push ./src/FluentUtils.DomainDrivenEnums/out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'src/**'
-      - '!**/*.md'
+      - "src/**"
+      - "!**/*.md"
 
 jobs:
   build-and-test:
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine Version
         id: gitversion
@@ -75,6 +75,7 @@ jobs:
       fromCompositeAttribute: ${{ steps.filter.outputs.fromCompositeAttribute }}
       endpointDefinitions: ${{ steps.filter.outputs.endpointDefinitions }}
       pipelineBehaviours: ${{ steps.filter.outputs.pipelineBehaviours }}
+      domainDrivenEnums: ${{ steps.filters.outputs.domainDrivenEnums }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -102,6 +103,8 @@ jobs:
               - 'src/FluentUtils.MinimalApis.EndpointDefinitions/**'
             pipelineBehaviours:
               - 'src/FluentUtils.MediatR.PipelineBehaviours/**'
+            domainDrivenEnums:
+              - 'src/FluentUtils.DomainDrivenEnums/**'
 
   publish-pipeline-behaviours:
     runs-on: ubuntu-latest
@@ -120,7 +123,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -150,7 +153,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -180,7 +183,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -210,7 +213,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -240,7 +243,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -270,7 +273,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -300,7 +303,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -330,7 +333,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -360,7 +363,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           source-url: https://nuget.pkg.github.com/draekien/index.json
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -372,6 +375,36 @@ jobs:
         run: |
           dotnet nuget push ./src/FluentUtils.EnumExtensions/out/*.nupkg --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
           dotnet nuget push ./src/FluentUtils.EnumExtensions/out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  publish-domain-driven-enums:
+    runs-on: ubuntu-latest
+    needs:
+      - calculate-version
+      - changes
+    name: Publish enum extensions NuGet package
+    if: ${{ needs.changes.outputs.domainDrivenEnums == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core Latest
+        uses: actions/setup-dotnet@v1
+        with:
+          source-url: https://nuget.pkg.github.com/draekien/index.json
+          dotnet-version: "6.0.x"
+          include-prerelease: true
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and pack
+        run: cd src/FluentUtils.DomainDrivenEnums && dotnet pack -c Release -o out -p:PackageVersion=${{ needs.calculate-version.outputs.nuGetVersionV2 }}
+
+      - name: Publish
+        run: |
+          dotnet nuget push ./src/FluentUtils.DomainDrivenEnums/out/*.nupkg --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push ./src/FluentUtils.DomainDrivenEnums/out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
     needs:
       - calculate-version
       - changes
-    name: Publish enum extensions NuGet package
+    name: Publish domain driven enums NuGet package
     if: ${{ needs.changes.outputs.domainDrivenEnums == 'true' }}
     steps:
       - name: Checkout repository

--- a/Draekien.FluentUtils.sln
+++ b/Draekien.FluentUtils.sln
@@ -8,6 +8,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.ValueObject.Samples", "samples\FluentUtils.ValueObject.Samples\FluentUtils.ValueObject.Samples.csproj", "{8EE6728D-9801-4B09-989A-10C383012AF5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9949BF8F-D969-45E2-956F-C7DC5D8D3544}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{1C830121-6036-4217-A15B-56D24D828F5F}"
 EndProject
@@ -48,6 +51,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.MinimalApis.EndpointDefinitions.UnitTests", "tests\FluentUtils.MinimalApis.EndpointDefinitions.UnitTests\FluentUtils.MinimalApis.EndpointDefinitions.UnitTests.csproj", "{E3C7F64D-A79E-4D6A-BB98-02A3DF0F0A6F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.MediatR.PipelineBehaviours", "src\FluentUtils.MediatR.PipelineBehaviours\FluentUtils.MediatR.PipelineBehaviours.csproj", "{8DDBF329-3169-4524-A9D9-C6331B36A8FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.DomainDrivenEnums", "src\FluentUtils.DomainDrivenEnums\FluentUtils.DomainDrivenEnums.csproj", "{7684AF36-667B-4BFA-8BFC-CAC595DACA50}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.DomainDrivenEnums.Samples", "samples\FluentUtils.DomainDrivenEnums.Samples\FluentUtils.DomainDrivenEnums.Samples.csproj", "{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -135,6 +142,14 @@ Global
 		{8DDBF329-3169-4524-A9D9-C6331B36A8FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DDBF329-3169-4524-A9D9-C6331B36A8FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DDBF329-3169-4524-A9D9-C6331B36A8FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7684AF36-667B-4BFA-8BFC-CAC595DACA50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7684AF36-667B-4BFA-8BFC-CAC595DACA50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7684AF36-667B-4BFA-8BFC-CAC595DACA50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7684AF36-667B-4BFA-8BFC-CAC595DACA50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,5 +178,7 @@ Global
 		{09C5458E-C1E6-4DD9-B477-22841C0979B4} = {1C830121-6036-4217-A15B-56D24D828F5F}
 		{E3C7F64D-A79E-4D6A-BB98-02A3DF0F0A6F} = {7FAB5149-A4E2-4437-801B-45FBC1122EC6}
 		{8DDBF329-3169-4524-A9D9-C6331B36A8FD} = {9949BF8F-D969-45E2-956F-C7DC5D8D3544}
+		{7684AF36-667B-4BFA-8BFC-CAC595DACA50} = {9949BF8F-D969-45E2-956F-C7DC5D8D3544}
+		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8} = {1C830121-6036-4217-A15B-56D24D828F5F}
 	EndGlobalSection
 EndGlobal

--- a/Draekien.FluentUtils.sln
+++ b/Draekien.FluentUtils.sln
@@ -15,6 +15,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{1C830121-6036-4217-A15B-56D24D828F5F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7FAB5149-A4E2-4437-801B-45FBC1122EC6}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.ValueObject.UnitTests", "tests\FluentUtils.ValueObject.UnitTests\FluentUtils.ValueObject.UnitTests.csproj", "{8D2F87C9-DCB5-4631-93AB-E734D2F22E5B}"
 EndProject

--- a/Draekien.FluentUtils.sln
+++ b/Draekien.FluentUtils.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.DomainDrivenEnu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.DomainDrivenEnums.Samples", "samples\FluentUtils.DomainDrivenEnums.Samples\FluentUtils.DomainDrivenEnums.Samples.csproj", "{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentUtils.DomainDrivenEnums.Tests", "tests\FluentUtils.DomainDrivenEnums.Tests\FluentUtils.DomainDrivenEnums.Tests.csproj", "{E8119118-129F-4388-A36F-86BE1FC7F7B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8119118-129F-4388-A36F-86BE1FC7F7B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8119118-129F-4388-A36F-86BE1FC7F7B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8119118-129F-4388-A36F-86BE1FC7F7B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8119118-129F-4388-A36F-86BE1FC7F7B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -183,5 +189,6 @@ Global
 		{8DDBF329-3169-4524-A9D9-C6331B36A8FD} = {9949BF8F-D969-45E2-956F-C7DC5D8D3544}
 		{7684AF36-667B-4BFA-8BFC-CAC595DACA50} = {9949BF8F-D969-45E2-956F-C7DC5D8D3544}
 		{BEC34862-B01B-44B6-BE6F-8C07C6F2F5A8} = {1C830121-6036-4217-A15B-56D24D828F5F}
+		{E8119118-129F-4388-A36F-86BE1FC7F7B3} = {7FAB5149-A4E2-4437-801B-45FBC1122EC6}
 	EndGlobalSection
 EndGlobal

--- a/samples/FluentUtils.DomainDrivenEnums.Samples/CustomerType.cs
+++ b/samples/FluentUtils.DomainDrivenEnums.Samples/CustomerType.cs
@@ -1,6 +1,6 @@
 ﻿namespace FluentUtils.DomainDrivenEnums.Samples;
 
-public record CustomerType : DomainDrivenEnum
+public sealed class CustomerType : DomainDrivenEnum
 {
     public static readonly CustomerType Standard = new(0, "Standard", 0.0, 4);
     public static readonly CustomerType Premium = new(1, "Premium", 0.1, 2);
@@ -19,7 +19,7 @@ public record CustomerType : DomainDrivenEnum
     public double Discount { get; }
 }
 
-public class Customer
+public sealed class Customer
 {
     public Customer(Guid id, CustomerType? customerType)
     {
@@ -32,7 +32,7 @@ public class Customer
     public CustomerType CustomerType { get; }
 }
 
-public class UsageExample
+public sealed class UsageExample
 {
     public IEnumerable<Customer> GetBySlaGreaterThan2Days(IEnumerable<Customer> customers)
     {

--- a/samples/FluentUtils.DomainDrivenEnums.Samples/CustomerType.cs
+++ b/samples/FluentUtils.DomainDrivenEnums.Samples/CustomerType.cs
@@ -1,0 +1,46 @@
+﻿namespace FluentUtils.DomainDrivenEnums.Samples;
+
+public record CustomerType : DomainDrivenEnum
+{
+    public static readonly CustomerType Standard = new(0, "Standard", 0.0, 4);
+    public static readonly CustomerType Premium = new(1, "Premium", 0.1, 2);
+    public static readonly CustomerType Vip = new(2, "VIP", 0.2, 1);
+
+    private CustomerType(int value, string displayName, double discount, int serviceLevelAgreementDays) : base(
+        value,
+        displayName)
+    {
+        Discount = discount;
+        ServiceLevelAgreementDays = serviceLevelAgreementDays;
+    }
+
+    public int ServiceLevelAgreementDays { get; }
+
+    public double Discount { get; }
+}
+
+public class Customer
+{
+    public Customer(Guid id, CustomerType? customerType)
+    {
+        Id = id;
+        CustomerType = customerType ?? CustomerType.Standard;
+    }
+
+    public Guid Id { get; }
+
+    public CustomerType CustomerType { get; }
+}
+
+public class UsageExample
+{
+    public IEnumerable<Customer> GetBySlaGreaterThan2Days(IEnumerable<Customer> customers)
+    {
+        return customers.Where(c => c.CustomerType.ServiceLevelAgreementDays >= 2);
+    }
+
+    public IEnumerable<Customer> GetPremiumCustomers(IEnumerable<Customer> customers)
+    {
+        return customers.Where(c => c.CustomerType == CustomerType.Premium);
+    }
+}

--- a/samples/FluentUtils.DomainDrivenEnums.Samples/FluentUtils.DomainDrivenEnums.Samples.csproj
+++ b/samples/FluentUtils.DomainDrivenEnums.Samples/FluentUtils.DomainDrivenEnums.Samples.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\FluentUtils.DomainDrivenEnums\FluentUtils.DomainDrivenEnums.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,16 @@
+﻿<Project>
+    <PropertyGroup>
+        <Authors>draekien</Authors>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <Copyright>William Pei</Copyright>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
+    </ItemGroup>
+</Project>

--- a/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
@@ -4,22 +4,14 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Microsoft.Extensions.DependencyInjection</RootNamespace>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection</Title>
         <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>Dependency injection extensions for the FluentUtils.AutoMapper library.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\FluentUtils.AutoMapper\FluentUtils.AutoMapper.csproj" />
+        <ProjectReference Include="..\FluentUtils.AutoMapper\FluentUtils.AutoMapper.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection/FluentUtils.AutoMapper.Extensions.Microsoft.DependencyInjection.csproj
@@ -8,6 +8,7 @@
         <Authors>draekien</Authors>
         <Description>Dependency injection extensions for the FluentUtils.AutoMapper library.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.AutoMapper/FluentUtils.AutoMapper.csproj
+++ b/src/FluentUtils.AutoMapper/FluentUtils.AutoMapper.csproj
@@ -3,17 +3,8 @@
     <PropertyGroup>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.AutoMapper</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A set of utils for making AutoMapper configuration easier.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/src/FluentUtils.AutoMapper/FluentUtils.AutoMapper.csproj
+++ b/src/FluentUtils.AutoMapper/FluentUtils.AutoMapper.csproj
@@ -6,6 +6,7 @@
         <Title>FluentUtils.AutoMapper</Title>
         <Description>A set of utils for making AutoMapper configuration easier.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
+++ b/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
@@ -38,20 +38,14 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
     /// </summary>
     /// <typeparam name="TEnum">The domain driven enum type</typeparam>
     /// <returns>All declared instances of the domain driven enum type</returns>
-    public static IEnumerable<TEnum> GetAll<TEnum>() where TEnum : DomainDrivenEnum, new()
+    public static IEnumerable<TEnum> GetAll<TEnum>() where TEnum : DomainDrivenEnum
     {
         Type type = typeof(TEnum);
         FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
-        foreach (FieldInfo field in fields)
-        {
-            var instance = new TEnum();
+        IEnumerable<object> values = fields.Select(field => field.GetValue(null));
 
-            if (field.GetValue(instance) is TEnum locatedValue)
-            {
-                yield return locatedValue;
-            }
-        }
+        return values.Cast<TEnum>();
     }
 
     /// <summary>
@@ -60,7 +54,7 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
     /// <param name="value">The index value to parse</param>
     /// <typeparam name="TEnum">The domain driven enum type</typeparam>
     /// <returns>The parsed instance of TEnum</returns>
-    public static TEnum FromValue<TEnum>(int value) where TEnum : DomainDrivenEnum, new()
+    public static TEnum FromValue<TEnum>(int value) where TEnum : DomainDrivenEnum
     {
         TEnum matching = Parse<TEnum, int>(value, "value", item => item.Value == value);
 
@@ -93,7 +87,7 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
         TValue value,
         string description,
         Func<TDomainDrivenEnum, bool> predicate)
-        where TDomainDrivenEnum : DomainDrivenEnum, new()
+        where TDomainDrivenEnum : DomainDrivenEnum
     {
         TDomainDrivenEnum? matching = GetAll<TDomainDrivenEnum>().FirstOrDefault(predicate);
 

--- a/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
+++ b/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
@@ -1,0 +1,108 @@
+﻿namespace FluentUtils.DomainDrivenEnums;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+
+/// <summary>
+/// A record which represents an enumeration member with domain specific properties
+/// </summary>
+/// <param name="Value">The index value of the enumeration instance</param>
+/// <param name="DisplayName">The display name of the enumeration instance</param>
+[PublicAPI]
+public abstract record DomainDrivenEnum(int Value, string DisplayName) : IComparable<DomainDrivenEnum>
+{
+    /// <summary>
+    /// The index value of the enumeration instance
+    /// </summary>
+    public int Value { get; } = Value;
+
+    /// <summary>
+    /// The display name of the enumeration instance
+    /// </summary>
+    public string DisplayName { get; } = DisplayName;
+
+    /// <inheritdoc />
+    public int CompareTo(DomainDrivenEnum? other)
+    {
+        if (ReferenceEquals(this, other)) return 0;
+        if (ReferenceEquals(null, other)) return 1;
+
+        return Value.CompareTo(other.Value);
+    }
+
+    /// <summary>
+    /// Gets all declared instances of domain driven enums for a given TEnum type
+    /// </summary>
+    /// <typeparam name="TEnum">The domain driven enum type</typeparam>
+    /// <returns>All declared instances of the domain driven enum type</returns>
+    public static IEnumerable<TEnum> GetAll<TEnum>() where TEnum : DomainDrivenEnum, new()
+    {
+        Type type = typeof(TEnum);
+        FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+        foreach (FieldInfo field in fields)
+        {
+            var instance = new TEnum();
+
+            if (field.GetValue(instance) is TEnum locatedValue)
+            {
+                yield return locatedValue;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses the provided value to provide the matching instance of TEnum
+    /// </summary>
+    /// <param name="value">The index value to parse</param>
+    /// <typeparam name="TEnum">The domain driven enum type</typeparam>
+    /// <returns>The parsed instance of TEnum</returns>
+    public static TEnum FromValue<TEnum>(int value) where TEnum : DomainDrivenEnum, new()
+    {
+        TEnum matching = Parse<TEnum, int>(value, "value", item => item.Value == value);
+
+        return matching;
+    }
+
+    /// <summary>
+    /// Parses the provided display name to provide the matching instance of TEnum
+    /// </summary>
+    /// <param name="displayName">The display name to parse</param>
+    /// <typeparam name="TEnum">The domain driven enum type</typeparam>
+    /// <returns>THe parsed instance of TEnum</returns>
+    public static TEnum FromDisplayName<TEnum>(string displayName) where TEnum : DomainDrivenEnum, new()
+    {
+        TEnum matching = Parse<TEnum, string>(
+            displayName,
+            "display name",
+            item => item.DisplayName.Equals(displayName, StringComparison.OrdinalIgnoreCase));
+
+        return matching;
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return DisplayName;
+    }
+
+    private static TDomainDrivenEnum Parse<TDomainDrivenEnum, TValue>(
+        TValue value,
+        string description,
+        Func<TDomainDrivenEnum, bool> predicate)
+        where TDomainDrivenEnum : DomainDrivenEnum, new()
+    {
+        TDomainDrivenEnum? matching = GetAll<TDomainDrivenEnum>().FirstOrDefault(predicate);
+
+        if (matching == null)
+        {
+            throw new InvalidOperationException(
+                $"'{value}' is not a valid {description} in {typeof(TDomainDrivenEnum)}.");
+        }
+
+        return matching;
+    }
+}

--- a/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
+++ b/src/FluentUtils.DomainDrivenEnums/DomainDrivenEnum.cs
@@ -7,22 +7,31 @@ using System.Reflection;
 using JetBrains.Annotations;
 
 /// <summary>
-/// A record which represents an enumeration member with domain specific properties
+/// Represents an enumeration member with domain specific properties
 /// </summary>
-/// <param name="Value">The index value of the enumeration instance</param>
-/// <param name="DisplayName">The display name of the enumeration instance</param>
 [PublicAPI]
-public abstract record DomainDrivenEnum(int Value, string DisplayName) : IComparable<DomainDrivenEnum>
+public abstract class DomainDrivenEnum : IComparable<DomainDrivenEnum>, IEquatable<DomainDrivenEnum>
 {
+    /// <summary>
+    /// A record which represents an enumeration member with domain specific properties
+    /// </summary>
+    /// <param name="value">The index value of the enumeration instance</param>
+    /// <param name="displayName">The display name of the enumeration instance</param>
+    protected DomainDrivenEnum(int value, string displayName)
+    {
+        Value = value;
+        DisplayName = displayName;
+    }
+
     /// <summary>
     /// The index value of the enumeration instance
     /// </summary>
-    public int Value { get; } = Value;
+    public int Value { get; }
 
     /// <summary>
     /// The display name of the enumeration instance
     /// </summary>
-    public string DisplayName { get; } = DisplayName;
+    public string DisplayName { get; }
 
     /// <inheritdoc />
     public int CompareTo(DomainDrivenEnum? other)
@@ -31,6 +40,15 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
         if (ReferenceEquals(null, other)) return 1;
 
         return Value.CompareTo(other.Value);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(DomainDrivenEnum? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return Value.Equals(other.Value);
     }
 
     /// <summary>
@@ -64,15 +82,15 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
     /// <summary>
     /// Parses the provided display name to provide the matching instance of TEnum
     /// </summary>
-    /// <param name="displayName">The display name to parse</param>
+    /// <param name="value">The display name to parse</param>
     /// <typeparam name="TEnum">The domain driven enum type</typeparam>
     /// <returns>THe parsed instance of TEnum</returns>
-    public static TEnum FromDisplayName<TEnum>(string displayName) where TEnum : DomainDrivenEnum, new()
+    public static TEnum FromDisplayName<TEnum>(string value) where TEnum : DomainDrivenEnum
     {
         TEnum matching = Parse<TEnum, string>(
-            displayName,
+            value,
             "display name",
-            item => item.DisplayName.Equals(displayName, StringComparison.OrdinalIgnoreCase));
+            item => item.DisplayName.Equals(value, StringComparison.OrdinalIgnoreCase));
 
         return matching;
     }
@@ -91,12 +109,50 @@ public abstract record DomainDrivenEnum(int Value, string DisplayName) : ICompar
     {
         TDomainDrivenEnum? matching = GetAll<TDomainDrivenEnum>().FirstOrDefault(predicate);
 
-        if (matching == null)
+        if (matching is null)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
                 $"'{value}' is not a valid {description} in {typeof(TDomainDrivenEnum)}.");
         }
 
         return matching;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        if (obj is not DomainDrivenEnum other) return false;
+        if (GetType() != obj.GetType()) return false;
+
+        return Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return Value ^ 41;
+    }
+
+    /// <summary>
+    /// Compares two instances of <see cref="DomainDrivenEnum" /> to see if they are equal
+    /// </summary>
+    /// <param name="left">The value on the left side of the equality operator</param>
+    /// <param name="right">The value on the right side of the equality operator</param>
+    /// <returns>true if they are equal</returns>
+    public static bool operator ==(DomainDrivenEnum? left, DomainDrivenEnum? right)
+    {
+        return Equals(left, right);
+    }
+
+    /// <summary>
+    /// Compares two instances of <see cref="DomainDrivenEnum" /> to see if they are not equal
+    /// </summary>
+    /// <param name="left">The value on the left side of the inequality operator</param>
+    /// <param name="right">The value on the right side of the inequality operator</param>
+    /// <returns>true if they are not equal</returns>
+    public static bool operator !=(DomainDrivenEnum? left, DomainDrivenEnum? right)
+    {
+        return !Equals(left, right);
     }
 }

--- a/src/FluentUtils.DomainDrivenEnums/FluentUtils.DomainDrivenEnums.csproj
+++ b/src/FluentUtils.DomainDrivenEnums/FluentUtils.DomainDrivenEnums.csproj
@@ -4,6 +4,9 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Title>FluentUtils.DomainDrivenEnums</Title>
+        <Description>Boilerplate for enumeration classes</Description>
     </PropertyGroup>
 
 </Project>

--- a/src/FluentUtils.DomainDrivenEnums/FluentUtils.DomainDrivenEnums.csproj
+++ b/src/FluentUtils.DomainDrivenEnums/FluentUtils.DomainDrivenEnums.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <Nullable>enable</Nullable>
+        <LangVersion>10</LangVersion>
+    </PropertyGroup>
+
+</Project>

--- a/src/FluentUtils.DomainDrivenEnums/README.md
+++ b/src/FluentUtils.DomainDrivenEnums/README.md
@@ -1,0 +1,53 @@
+﻿# FluentUtils.DomainDrivenEnums
+
+## Example Usage
+
+Declare a class for your enum type and inherit from `DomainDrivenEnum`. Then, create the private constructor
+and additional properties required by your enum type, and declare `public static readonly` members for your enum values.
+
+```c#
+public sealed class CustomerType : DomainDrivenEnum
+{
+    public static readonly CustomerType Standard = new(0, "Standard", 0.0, 4);
+    public static readonly CustomerType Premium = new(1, "Premium", 0.1, 2);
+    public static readonly CustomerType Vip = new(2, "VIP", 0.2, 1);
+
+    private CustomerType(int value, string displayName, double discount, int serviceLevelAgreementDays) : base(
+        value,
+        displayName)
+    {
+        Discount = discount;
+        ServiceLevelAgreementDays = serviceLevelAgreementDays;
+    }
+
+    public int ServiceLevelAgreementDays { get; }
+
+    public double Discount { get; }
+}
+
+public sealed class Customer
+{
+    public Customer(Guid id, CustomerType? customerType)
+    {
+        Id = id;
+        CustomerType = customerType ?? CustomerType.Standard;
+    }
+
+    public Guid Id { get; }
+
+    public CustomerType CustomerType { get; }
+}
+
+public sealed class UsageExample
+{
+    public IEnumerable<Customer> GetBySlaGreaterThan2Days(IEnumerable<Customer> customers)
+    {
+        return customers.Where(c => c.CustomerType.ServiceLevelAgreementDays >= 2);
+    }
+
+    public IEnumerable<Customer> GetPremiumCustomers(IEnumerable<Customer> customers)
+    {
+        return customers.Where(c => c.CustomerType == CustomerType.Premium);
+    }
+}
+```

--- a/src/FluentUtils.EnumExtensions/FluentUtils.EnumExtensions.csproj
+++ b/src/FluentUtils.EnumExtensions/FluentUtils.EnumExtensions.csproj
@@ -3,17 +3,8 @@
     <PropertyGroup>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.EnumExtensions</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A set of utils for working with enums.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/src/FluentUtils.EnumExtensions/FluentUtils.EnumExtensions.csproj
+++ b/src/FluentUtils.EnumExtensions/FluentUtils.EnumExtensions.csproj
@@ -6,6 +6,7 @@
         <Title>FluentUtils.EnumExtensions</Title>
         <Description>A set of utils for working with enums.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
 </Project>

--- a/src/FluentUtils.FromCompositeAttribute/FluentUtils.FromCompositeAttribute.csproj
+++ b/src/FluentUtils.FromCompositeAttribute/FluentUtils.FromCompositeAttribute.csproj
@@ -4,21 +4,13 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.FromCompositeAttribute</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A model binding attribute that allows for binding of request properties from multiple sources.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FluentUtils.FromCompositeAttribute/FluentUtils.FromCompositeAttribute.csproj
+++ b/src/FluentUtils.FromCompositeAttribute/FluentUtils.FromCompositeAttribute.csproj
@@ -7,6 +7,7 @@
         <Title>FluentUtils.FromCompositeAttribute</Title>
         <Description>A model binding attribute that allows for binding of request properties from multiple sources.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.MediatR.Pagination.AspNetCore/FluentUtils.MediatR.Pagination.AspNetCore.csproj
+++ b/src/FluentUtils.MediatR.Pagination.AspNetCore/FluentUtils.MediatR.Pagination.AspNetCore.csproj
@@ -7,6 +7,7 @@
         <Title>FluentUtils.MediatR.Pagination.AspNetCore</Title>
         <Description>A set of utils for returning pagination results when using MediatR in AspNetCore Web APIs.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.MediatR.Pagination.AspNetCore/FluentUtils.MediatR.Pagination.AspNetCore.csproj
+++ b/src/FluentUtils.MediatR.Pagination.AspNetCore/FluentUtils.MediatR.Pagination.AspNetCore.csproj
@@ -4,28 +4,19 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>FluentUtils.MediatR.Pagination</RootNamespace>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.MediatR.Pagination.AspNetCore</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A set of utils for returning pagination results when using MediatR in AspNetCore Web APIs.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\FluentUtils.MediatR.Pagination\FluentUtils.MediatR.Pagination.csproj" />
+        <ProjectReference Include="..\FluentUtils.MediatR.Pagination\FluentUtils.MediatR.Pagination.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FluentUtils.MediatR.Pagination/FluentUtils.MediatR.Pagination.csproj
+++ b/src/FluentUtils.MediatR.Pagination/FluentUtils.MediatR.Pagination.csproj
@@ -6,6 +6,7 @@
         <Title>FluentUtils.MediatR.Pagination</Title>
         <Description>A set of utils for returning pagination results when using MediatR.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.MediatR.Pagination/FluentUtils.MediatR.Pagination.csproj
+++ b/src/FluentUtils.MediatR.Pagination/FluentUtils.MediatR.Pagination.csproj
@@ -3,22 +3,13 @@
     <PropertyGroup>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.MediatR.Pagination</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A set of utils for returning pagination results when using MediatR.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="11.0.0" />
+        <PackageReference Include="MediatR" Version="11.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FluentUtils.MediatR.PipelineBehaviours/FluentUtils.MediatR.PipelineBehaviours.csproj
+++ b/src/FluentUtils.MediatR.PipelineBehaviours/FluentUtils.MediatR.PipelineBehaviours.csproj
@@ -6,6 +6,7 @@
         <Title>FluentUtils.MediatR.PipelineBehaviours</Title>
         <Description>A set of pipeline behaviours for use with MediatR.</Description>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.MediatR.PipelineBehaviours/FluentUtils.MediatR.PipelineBehaviours.csproj
+++ b/src/FluentUtils.MediatR.PipelineBehaviours/FluentUtils.MediatR.PipelineBehaviours.csproj
@@ -3,17 +3,8 @@
     <PropertyGroup>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.MediatR.PipelineBehaviours</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A set of pipeline behaviours for use with MediatR.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/src/FluentUtils.MinimalApis.EndpointDefinitions/FluentUtils.MinimalApis.EndpointDefinitions.csproj
+++ b/src/FluentUtils.MinimalApis.EndpointDefinitions/FluentUtils.MinimalApis.EndpointDefinitions.csproj
@@ -7,6 +7,7 @@
         <Title>FluentUtils.MinimalApis.EndpointDefinitions</Title>
         <Description>A more structured approach to minimal apis.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/FluentUtils.MinimalApis.EndpointDefinitions/FluentUtils.MinimalApis.EndpointDefinitions.csproj
+++ b/src/FluentUtils.MinimalApis.EndpointDefinitions/FluentUtils.MinimalApis.EndpointDefinitions.csproj
@@ -4,25 +4,17 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
         <Title>FluentUtils.MinimalApis.EndpointDefinitions</Title>
-        <Authors>draekien</Authors>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Description>A more structured approach to minimal apis.</Description>
-        <Copyright>William Pei</Copyright>
-        <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     </ItemGroup>
-    
-    <ItemGroup>      
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FluentUtils.ValueObject/FluentUtils.ValueObject.csproj
+++ b/src/FluentUtils.ValueObject/FluentUtils.ValueObject.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <Title>FluentUtils.ValueObject</Title>
-    <Description>An implementation of ValueObject.</Description>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Title>FluentUtils.ValueObject</Title>
+        <Description>An implementation of ValueObject.</Description>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
 </Project>

--- a/src/FluentUtils.ValueObject/FluentUtils.ValueObject.csproj
+++ b/src/FluentUtils.ValueObject/FluentUtils.ValueObject.csproj
@@ -3,17 +3,8 @@
   <PropertyGroup>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/draekien/Draekien.FluentUtils</RepositoryUrl>
     <Title>FluentUtils.ValueObject</Title>
-    <Authors>draekien</Authors>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Description>An implementation of ValueObject.</Description>
-    <Copyright>William Pei</Copyright>
-    <PackageProjectUrl>https://github.com/draekien/Draekien.FluentUtils</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,21 @@
+﻿<Project>
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.17.0" />
+        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/tests/FluentUtils.AutoMapper.UnitTests/FluentUtils.AutoMapper.UnitTests.csproj
+++ b/tests/FluentUtils.AutoMapper.UnitTests/FluentUtils.AutoMapper.UnitTests.csproj
@@ -3,32 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\samples\FluentUtils.AutoMapper.Samples\FluentUtils.AutoMapper.Samples.csproj" />
+        <ProjectReference Include="..\..\samples\FluentUtils.AutoMapper.Samples\FluentUtils.AutoMapper.Samples.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/FluentUtils.DomainDrivenEnums.Tests/DomainDrivenEnumFacts.cs
+++ b/tests/FluentUtils.DomainDrivenEnums.Tests/DomainDrivenEnumFacts.cs
@@ -1,0 +1,114 @@
+namespace FluentUtils.DomainDrivenEnums.Tests;
+
+using Samples;
+
+public class DomainDrivenEnumFacts
+{
+    [Fact]
+    public void WhenGettingAllDeclaredInstances_ThenReturnExpectedCollection()
+    {
+        // Act
+        List<CustomerType> members = DomainDrivenEnum.GetAll<CustomerType>().ToList();
+
+        // Assert
+        members.Should().ContainEquivalentOf(CustomerType.Premium);
+        members.Should().ContainEquivalentOf(CustomerType.Standard);
+        members.Should().ContainEquivalentOf(CustomerType.Vip);
+    }
+
+    [Fact]
+    public void GivenValueIsInEnum_WhenCreatingEnumFromValue_ThenReturnExpectedEnumMember()
+    {
+        // Arrange
+        int value = CustomerType.Standard.Value;
+
+        // Act
+        var result = DomainDrivenEnum.FromValue<CustomerType>(value);
+
+        // Assert
+        result.Should().BeEquivalentTo(CustomerType.Standard);
+    }
+
+    [Fact]
+    public void GivenValueIsNotInEnum_WhenCreatingEnumFromValue_ThenThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        const int value = 999;
+        Action action = () => DomainDrivenEnum.FromValue<CustomerType>(value);
+
+        // Act + Assert
+        action.Should()
+              .Throw<ArgumentOutOfRangeException>()
+              .WithParameterName("value")
+              .WithMessage($"'{value}' is not a valid value in {typeof(CustomerType)}. (Parameter 'value')");
+    }
+
+    [Fact]
+    public void GivenDisplayNameIsInEnum_WhenCreatingEnumFromDisplayName_ThenReturnExpectedEnumMember()
+    {
+        // Arrange
+        string displayName = CustomerType.Standard.DisplayName;
+
+        // Act
+        var result = DomainDrivenEnum.FromDisplayName<CustomerType>(displayName);
+
+        // Assert
+        result.Should().BeEquivalentTo(CustomerType.Standard);
+    }
+
+    [Fact]
+    public void GivenDisplayNameIsNotInEnum_WhenCreatingEnumFromDisplayName_ThenThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        const string displayName = "does not exist";
+        Action action = () => DomainDrivenEnum.FromDisplayName<CustomerType>(displayName);
+
+        // Act + Assert
+        action.Should()
+              .Throw<ArgumentOutOfRangeException>()
+              .WithParameterName("value")
+              .WithMessage(
+                   $"'{displayName}' is not a valid display name in {typeof(CustomerType)}. (Parameter 'value')");
+    }
+
+    [Fact]
+    public void WhenInvokingToString_ThenReturnDisplayName()
+    {
+        // Arrange
+        string expected = CustomerType.Standard.DisplayName;
+
+        // Act
+        var result = CustomerType.Standard.ToString();
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GivenTheSameEnumValues_WhenCheckingToSeeIfTheyAreEqual_ThenReturnTrue()
+    {
+        // Arrange
+        CustomerType first = CustomerType.Standard;
+        CustomerType second = CustomerType.Standard;
+
+        // Act
+        bool result = first.Equals(second);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentEnumValues_WhenCheckingToSeeIfTheyAreEqual_ThenReturnFalse()
+    {
+        // Arrange
+        CustomerType first = CustomerType.Standard;
+        CustomerType second = CustomerType.Premium;
+
+        // Act
+        bool result = first.Equals(second);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/tests/FluentUtils.DomainDrivenEnums.Tests/DomainDrivenEnumFacts.cs
+++ b/tests/FluentUtils.DomainDrivenEnums.Tests/DomainDrivenEnumFacts.cs
@@ -111,4 +111,51 @@ public class DomainDrivenEnumFacts
         // Assert
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public void WhenFilteringByProperties_ThenReturnExpected()
+    {
+        // Arrange
+        var customers = new List<Customer>
+        {
+            new(Guid.NewGuid(), CustomerType.Premium),
+            new(Guid.NewGuid(), CustomerType.Premium),
+            new(Guid.NewGuid(), CustomerType.Standard),
+            new(Guid.NewGuid(), CustomerType.Vip),
+            new(Guid.NewGuid(), CustomerType.Vip),
+        };
+
+        var sut = new UsageExample();
+
+        // Act
+        IEnumerable<Customer> result = sut.GetBySlaGreaterThan2Days(customers).ToList();
+
+        // Assert
+        result.Count().Should().Be(3);
+        result.Should().NotContain(r => r.CustomerType == CustomerType.Vip);
+    }
+
+    [Fact]
+    public void WhenFilteringByEnumMember_ThenReturnExpected()
+    {
+        // Arrange
+        var customers = new List<Customer>
+        {
+            new(Guid.NewGuid(), CustomerType.Premium),
+            new(Guid.NewGuid(), CustomerType.Premium),
+            new(Guid.NewGuid(), CustomerType.Standard),
+            new(Guid.NewGuid(), CustomerType.Vip),
+            new(Guid.NewGuid(), CustomerType.Vip),
+        };
+
+        var sut = new UsageExample();
+
+        // Act
+        IEnumerable<Customer> result = sut.GetPremiumCustomers(customers).ToList();
+
+        // Assert
+        result.Count().Should().Be(2);
+        result.Should().NotContain(r => r.CustomerType == CustomerType.Vip);
+        result.Should().NotContain(r => r.CustomerType == CustomerType.Standard);
+    }
 }

--- a/tests/FluentUtils.DomainDrivenEnums.Tests/FluentUtils.DomainDrivenEnums.Tests.csproj
+++ b/tests/FluentUtils.DomainDrivenEnums.Tests/FluentUtils.DomainDrivenEnums.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\samples\FluentUtils.DomainDrivenEnums.Samples\FluentUtils.DomainDrivenEnums.Samples.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/FluentUtils.DomainDrivenEnums.Tests/Usings.cs
+++ b/tests/FluentUtils.DomainDrivenEnums.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/tests/FluentUtils.EnumExtensions.UnitTests/FluentUtils.EnumExtensions.UnitTests.csproj
+++ b/tests/FluentUtils.EnumExtensions.UnitTests/FluentUtils.EnumExtensions.UnitTests.csproj
@@ -3,30 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\FluentUtils.EnumExtensions\FluentUtils.EnumExtensions.csproj" />
+        <ProjectReference Include="..\..\src\FluentUtils.EnumExtensions\FluentUtils.EnumExtensions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/FluentUtils.FromCompositeAttribute.UnitTests/FluentUtils.FromCompositeAttribute.UnitTests.csproj
+++ b/tests/FluentUtils.FromCompositeAttribute.UnitTests/FluentUtils.FromCompositeAttribute.UnitTests.csproj
@@ -3,27 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\samples\FluentUtils.FromCompositeAttribute.Samples\FluentUtils.FromCompositeAttribute.Samples.csproj" />
+        <ProjectReference Include="..\..\samples\FluentUtils.FromCompositeAttribute.Samples\FluentUtils.FromCompositeAttribute.Samples.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/FluentUtils.MediatR.UnitTests/FluentUtils.MediatR.UnitTests.csproj
+++ b/tests/FluentUtils.MediatR.UnitTests/FluentUtils.MediatR.UnitTests.csproj
@@ -3,32 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\samples\FluentUtils.MediatR.Samples\FluentUtils.MediatR.Samples.csproj" />
+        <ProjectReference Include="..\..\samples\FluentUtils.MediatR.Samples\FluentUtils.MediatR.Samples.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/FluentUtils.MinimalApis.EndpointDefinitions.UnitTests/FluentUtils.MinimalApis.EndpointDefinitions.UnitTests.csproj
+++ b/tests/FluentUtils.MinimalApis.EndpointDefinitions.UnitTests/FluentUtils.MinimalApis.EndpointDefinitions.UnitTests.csproj
@@ -3,27 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\samples\FluentUtils.MinimalApis.EndpointDefinitions.Samples\FluentUtils.MinimalApis.EndpointDefinitions.Samples.csproj" />
+        <ProjectReference Include="..\..\samples\FluentUtils.MinimalApis.EndpointDefinitions.Samples\FluentUtils.MinimalApis.EndpointDefinitions.Samples.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/FluentUtils.ValueObject.UnitTests/FluentUtils.ValueObject.UnitTests.csproj
+++ b/tests/FluentUtils.ValueObject.UnitTests/FluentUtils.ValueObject.UnitTests.csproj
@@ -3,31 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\samples\FluentUtils.ValueObject.Samples\FluentUtils.ValueObject.Samples.csproj" />
+        <ProjectReference Include="..\..\samples\FluentUtils.ValueObject.Samples\FluentUtils.ValueObject.Samples.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Introduces a new project called `FluentUtils.DomainDrivenEnums` which provides the boiler plate code required to define a complex enumeration record which can contain your business logic.

See https://learn.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types