### PR TITLE
feat(monad)!: add ensure extensions

### DIFF
--- a/samples/FluentUtils.Monad.Samples/Example.cs
+++ b/samples/FluentUtils.Monad.Samples/Example.cs
@@ -32,9 +32,9 @@ public static class PersonFactory
     }
 }
 
-public class PersonGenerator
+public static class PersonGenerator
 {
-    public IEnumerable<Person> Generate(int number)
+    public static IEnumerable<Person> Generate(int number)
     {
         for (var i = 0; i < number; i++)
         {

--- a/src/FluentUtils.Monad/AssemblyInfo.cs
+++ b/src/FluentUtils.Monad/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FluentUtils.Monad.UnitTests")]

--- a/src/FluentUtils.Monad/ErrorResultType.cs
+++ b/src/FluentUtils.Monad/ErrorResultType.cs
@@ -25,7 +25,7 @@ public sealed record ErrorResultType<T> : ResultType<T> where T : notnull
     public Error Error { get; }
 
     /// <summary>
-    ///     Converts a <see cref="ErrorResultType{T}" /> of type <see cref="TIn" /> to
+    ///     Converts a <see cref="ErrorResultType{T}" /> of type <see cref="T" /> to
     ///     a type of <see cref="TOut" />, preserving the error inside the result
     /// </summary>
     /// <typeparam name="TOut">The output type</typeparam>

--- a/src/FluentUtils.Monad/Extensions/EnsureAsyncExtensions.cs
+++ b/src/FluentUtils.Monad/Extensions/EnsureAsyncExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace FluentUtils.Monad.Extensions;
+
+/// <summary>
+///     Extensions for ensuring the value of an asynchronous
+///     <see cref="ResultType{T}" />
+/// </summary>
+[PublicAPI]
+public static class EnsureAsyncExtensions
+{
+    /// <summary>
+    ///     Ensures the value inside an asynchronous <see cref="ResultType{T}" />
+    ///     matches the provided predicate
+    /// </summary>
+    /// <param name="resultTask">
+    ///     A task which when completed returns a
+    ///     <see cref="ResultType{T}" />
+    /// </param>
+    /// <param name="predicate">An asynchronous predicate to execute</param>
+    /// <param name="error">
+    ///     Optional. The <see cref="Error" /> that will be assigned to
+    ///     the result if it does not pass the predicate
+    /// </param>
+    /// <typeparam name="T">The result value type</typeparam>
+    /// <returns>The original result on success, otherwise an error result</returns>
+    public static Task<ResultType<T>> EnsureAsync<T>(
+        this Task<ResultType<T>> resultTask,
+        Func<T, CancellationToken, Task<bool>> predicate,
+        Error? error = default) where T : notnull => resultTask.MatchAsync(
+        async (value, ct) => await predicate(value, ct)
+            ? await resultTask
+            : await Result.ErrorAsync<T>(MonadErrors.FailedPredicate, ct),
+        Result.ErrorAsync<T>);
+}

--- a/src/FluentUtils.Monad/Extensions/EnsureAsyncExtensions.cs
+++ b/src/FluentUtils.Monad/Extensions/EnsureAsyncExtensions.cs
@@ -28,6 +28,7 @@ public static class EnsureAsyncExtensions
         Error? error = default) where T : notnull => resultTask.MatchAsync(
         async (value, ct) => await predicate(value, ct)
             ? await resultTask
-            : await Result.ErrorAsync<T>(MonadErrors.FailedPredicate, ct),
+            : error
+              ?? await Result.ErrorAsync<T>(MonadErrors.FailedPredicate, ct),
         Result.ErrorAsync<T>);
 }

--- a/src/FluentUtils.Monad/Extensions/EnsureExtensions.cs
+++ b/src/FluentUtils.Monad/Extensions/EnsureExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace FluentUtils.Monad.Extensions;
+
+/// <summary>
+///     Extensions for ensuring a <see cref="ResultType{T}" /> satisfies a
+///     predicate
+/// </summary>
+[PublicAPI]
+public static class EnsureExtensions
+{
+    /// <summary>
+    ///     Ensures the value inside a <see cref="ResultType{T}" /> matches the
+    ///     provided predicate
+    /// </summary>
+    /// <param name="result">The <see cref="ResultType{T}" /> to be checked</param>
+    /// <param name="predicate">
+    ///     The predicate that will be used to evaluate the
+    ///     <see cref="ResultType{T}" />
+    /// </param>
+    /// <param name="error">
+    ///     Optional. The <see cref="Error" /> that will be assigned to
+    ///     the result if it does not pass the predicate
+    /// </param>
+    /// <typeparam name="T">The result value type</typeparam>
+    /// <returns>The original result on success, otherwise an error result</returns>
+    public static ResultType<T> Ensure<T>(
+        this ResultType<T> result,
+        Func<T, bool> predicate,
+        Error? error = default) where T : notnull =>
+        result.Match(
+            value => predicate(value)
+                ? result
+                : Result.Error<T>(error ?? MonadErrors.FailedPredicate),
+            Result.Error<T>);
+}

--- a/src/FluentUtils.Monad/Extensions/PipeExtensions.cs
+++ b/src/FluentUtils.Monad/Extensions/PipeExtensions.cs
@@ -23,7 +23,20 @@ public static class PipeExtensions
     /// </returns>
     public static ResultType<TOut> Pipe<TIn, TOut>(
         this ResultType<TIn> result,
-        Func<TIn, ResultType<TOut>> pipe
+        Func<TIn, TOut> pipe
     ) where TIn : notnull where TOut : notnull =>
-        result.Match(pipe, Result.Error<TOut>);
+        result.Match(
+            value =>
+            {
+                try
+                {
+                    TOut transformed = pipe(value);
+                    return Result.Ok(transformed);
+                }
+                catch (Exception ex)
+                {
+                    return Result.Error<TOut>("Failed to pipe value", ex);
+                }
+            },
+            Result.Error<TOut>);
 }

--- a/src/FluentUtils.Monad/MonadErrors.cs
+++ b/src/FluentUtils.Monad/MonadErrors.cs
@@ -1,0 +1,15 @@
+﻿namespace FluentUtils.Monad;
+
+/// <summary>
+/// Built in errors
+/// </summary>
+[PublicAPI]
+public static class MonadErrors
+{
+    /// <summary>
+    /// The value of a result does not match a predicate
+    /// </summary>
+    public static readonly Error FailedPredicate = new(
+        "FM_01",
+        "Result value does not match predicate.");
+}

--- a/src/FluentUtils.Monad/Result.cs
+++ b/src/FluentUtils.Monad/Result.cs
@@ -20,7 +20,7 @@ public static class Result
     /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
     /// <typeparam name="T">The value type</typeparam>
     /// <returns>The created result</returns>
-    public static Task<ResultType<T>> OkAsync<T>(
+    internal static Task<ResultType<T>> OkAsync<T>(
         T value,
         CancellationToken cancellationToken = default
     ) where T : notnull =>
@@ -32,7 +32,7 @@ public static class Result
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
     /// <returns>The created result</returns>
-    public static Task<ResultType<Empty>> OkAsync(
+    internal static Task<ResultType<Empty>> OkAsync(
         CancellationToken cancellationToken = default
     ) => OkAsync<Empty>(default, cancellationToken);
 
@@ -61,7 +61,7 @@ public static class Result
     ///     counterpart
     /// </typeparam>
     /// <returns>The <see cref="ResultType{T}" /> <see cref="Task" /></returns>
-    public static Task<ResultType<T>> ErrorAsync<T>(
+    internal static Task<ResultType<T>> ErrorAsync<T>(
         Error error,
         CancellationToken cancellationToken = default
     )
@@ -74,7 +74,7 @@ public static class Result
     /// <param name="error">The <see cref="Error(FluentUtils.Monad.Error)" /></param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
     /// <returns>The created result</returns>
-    public static Task<ResultType<Empty>> ErrorAsync(
+    internal static Task<ResultType<Empty>> ErrorAsync(
         Error error,
         CancellationToken cancellationToken = default
     ) => ErrorAsync<Empty>(error, cancellationToken);

--- a/tests/FluentUtils.Monad.UnitTests/Extensions/EnsureAsyncExtensionsTests.cs
+++ b/tests/FluentUtils.Monad.UnitTests/Extensions/EnsureAsyncExtensionsTests.cs
@@ -1,0 +1,93 @@
+﻿namespace FluentUtils.Monad.UnitTests.Extensions;
+
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Monad.Extensions;
+
+public class EnsureAsyncExtensionsTests
+{
+    private readonly Fixture _fixture;
+
+    public EnsureAsyncExtensionsTests()
+    {
+        _fixture = new Fixture();
+        _fixture.Customize(new AutoNSubstituteCustomization());
+    }
+
+    [Fact]
+    public async Task
+        GivenResultValueMatchesPredicate_WhenEnsuringResult_ThenReturnOkResult()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        Task<ResultType<ITestType>> result = Result.OkAsync(testType);
+
+        // Act
+        ResultType<ITestType> output =
+            await result.EnsureAsync((_, _) => Task.FromResult(true));
+
+        // Assert
+        output.Should().BeOfType<OkResultType<ITestType>>();
+    }
+
+    [Fact]
+    public async Task
+        GivenResultValueDoesNotMatchPredicate_WhenEnsuringResult_ThenReturnErrorResult()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        Task<ResultType<ITestType>> result = Result.OkAsync(testType);
+
+        // Act
+        ResultType<ITestType> output =
+            await result.EnsureAsync((_, _) => Task.FromResult(false));
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(MonadErrors.FailedPredicate);
+    }
+
+    [Fact]
+    public async Task
+        GivenResultValueDoesNotMatchPredicate_AndCustomErrorIsProvided_WhenEnsuringResult_ThenReturnCustomError()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        Task<ResultType<ITestType>> result = Result.OkAsync(testType);
+        var customError = _fixture.Freeze<Error>();
+
+        // Act
+        ResultType<ITestType> output = await result.EnsureAsync(
+            (_, _) => Task.FromResult(false),
+            customError);
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(customError);
+    }
+
+    [Fact]
+    public async Task
+        GivenResultIsAlreadyErrored_WhenEnsuringResult_ThenForwardError()
+    {
+        // Arrange
+        var customError = _fixture.Freeze<Error>();
+        Task<ResultType<ITestType>> errorResult =
+            Result.ErrorAsync<ITestType>(customError);
+
+        // Act
+        ResultType<ITestType> output =
+            await errorResult.EnsureAsync((_, _) => Task.FromResult(true));
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(customError);
+    }
+}

--- a/tests/FluentUtils.Monad.UnitTests/Extensions/EnsureExtensionsTests.cs
+++ b/tests/FluentUtils.Monad.UnitTests/Extensions/EnsureExtensionsTests.cs
@@ -1,0 +1,88 @@
+﻿namespace FluentUtils.Monad.UnitTests.Extensions;
+
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Monad.Extensions;
+
+public class EnsureExtensionsTests
+{
+    private readonly Fixture _fixture;
+
+    public EnsureExtensionsTests()
+    {
+        _fixture = new Fixture();
+        _fixture.Customize(new AutoNSubstituteCustomization());
+    }
+
+    [Fact]
+    public void
+        GivenResultValueMatchesPredicate_WhenEnsuringResult_ThenReturnOkResult()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        ResultType<ITestType> result = Result.Ok(testType);
+
+        // Act
+        ResultType<ITestType> output = result.Ensure(_ => true);
+
+        // Assert
+        output.Should().BeOfType<OkResultType<ITestType>>();
+    }
+
+    [Fact]
+    public void
+        GivenResultValueDoesNotMatchPredicate_WhenEnsuringResult_ThenReturnErrorResult()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        ResultType<ITestType> result = Result.Ok(testType);
+
+        // Act
+        ResultType<ITestType> output = result.Ensure(_ => false);
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(MonadErrors.FailedPredicate);
+    }
+
+    [Fact]
+    public void
+        GivenResultValueDoesNotMatchPredicate_AndCustomErrorIsProvided_WhenEnsuringResult_ThenReturnCustomError()
+    {
+        // Arrange
+        var testType = _fixture.Create<ITestType>();
+        ResultType<ITestType> result = Result.Ok(testType);
+        var customError = _fixture.Freeze<Error>();
+
+        // Act
+        ResultType<ITestType> output = result.Ensure(_ => false, customError);
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(customError);
+    }
+
+    [Fact]
+    public void
+        GivenResultIsAlreadyErrored_WhenEnsuringResult_ThenForwardError()
+    {
+        // Arrange
+        var customError = _fixture.Freeze<Error>();
+        ResultType<ITestType>
+            errorResult = Result.Error<ITestType>(customError);
+
+        // Act
+        ResultType<ITestType> output = errorResult.Ensure(_ => true);
+
+        // Assert
+        output.Should().BeOfType<ErrorResultType<ITestType>>();
+        output.As<ErrorResultType<ITestType>>()
+           .Error.Should()
+           .Be(customError);
+    }
+}

--- a/tests/FluentUtils.Monad.UnitTests/Extensions/PipeAsyncExtensionsTests.cs
+++ b/tests/FluentUtils.Monad.UnitTests/Extensions/PipeAsyncExtensionsTests.cs
@@ -19,7 +19,7 @@ public class PipeAsyncExtensionsTests
 
         // Act
         ResultType<ITestType> result =
-            await ok.PipeAsync((_, token) => Result.OkAsync(expected, token));
+            await ok.PipeAsync((_, _) => Task.FromResult(expected));
 
         // Assert
         result.Should().BeOfType<OkResultType<ITestType>>();
@@ -38,7 +38,7 @@ public class PipeAsyncExtensionsTests
 
         // Act
         ResultType<ITestType> result = await errorResult.PipeAsync(
-            (_, token) => Result.OkAsync(Substitute.For<ITestType>(), token)
+            (_, _) => Task.FromResult(Substitute.For<ITestType>())
         );
 
         // Assert

--- a/tests/FluentUtils.Monad.UnitTests/Extensions/PipeExtensionsTests.cs
+++ b/tests/FluentUtils.Monad.UnitTests/Extensions/PipeExtensionsTests.cs
@@ -19,7 +19,7 @@ public class PipeExtensionsTests
 
         // Act
         ResultType<ITestType> result =
-            ok.Pipe(_ => Result.Ok(expected));
+            ok.Pipe(_ => expected);
 
         // Assert
         result.Should().BeOfType<OkResultType<ITestType>>();
@@ -38,7 +38,7 @@ public class PipeExtensionsTests
 
         // Act
         ResultType<ITestType> result = errorResult.Pipe(
-            _ => Result.Ok(Substitute.For<ITestType>())
+            _ => Substitute.For<ITestType>()
         );
 
         // Assert


### PR DESCRIPTION
This change removes the  async Ok and Error methods that were accidentally exposed in the last monad version. As such it is a breaking change.